### PR TITLE
Fix dead links on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 | Application     | Find out how to use it: | 
 | --------------- |:-----------------:      | 
-| GradesHistogram | [link](seip2019/gradeshistogram/README_gradeshistogram.md)|
-| Java Metrics    | [link](seip2019/JavaCodeAnalysis/README_java_metrics.md)         |
+| GradesHistogram | [link](seip2019/gradeshistogram/README.md)|
+| Java Metrics    | [link](seip2019/JavaCodeAnalysis/README.md)         |
 
 Find the **AMAZING UML DIAGRAM** of Java Metrics [**here**](media/uml.png) 
 


### PR DESCRIPTION
When changing the README files on modules, I had to change the links at the main README.md file.

I take the initiative to merge it to master.